### PR TITLE
reallyWriteoutToDisk may also change/free the entry value

### DIFF
--- a/diskcache.c
+++ b/diskcache.c
@@ -1445,8 +1445,12 @@ destroyDiskEntry(ObjectPtr object, int d)
         entry = object->disk_entry;
         if(entry == NULL || entry == &negativeEntry)
             return 0;
-        if(diskCacheWriteoutOnClose > 0)
+        if(diskCacheWriteoutOnClose > 0) {
             reallyWriteoutToDisk(object, -1, diskCacheWriteoutOnClose);
+            entry = object->disk_entry;
+            if(entry == NULL || entry == &negativeEntry)
+                return 0;
+        }
     }
  again:
     rc = close(entry->fd);


### PR DESCRIPTION
I see frequent crashes in destroyDiskEntry which indicate the entry has already been freed. Upon inspection, I found this case where the call to reallyWriteoutToDisk leads to entry being freed before it returns.
