### PR TITLE
Expand tilde before openning log file.

### DIFF
--- a/log.c
+++ b/log.c
@@ -110,6 +110,7 @@ initLog(void)
 
     if(logFile != NULL && logFile->length > 0) {
         FILE *f;
+        logFile = expandTilde(logFile);
         f = openLogFile();
         if(f == NULL) {
             do_log_error(L_ERROR, errno, "Couldn't open log file %s",


### PR DESCRIPTION
In the configured path for the log file, the tilde is not expanded so that parsing `~/path/to/config` will cause polipo to complain "Couldn't open log file ~/path/to/config: No such file or directory".
