### PR TITLE
making it possible to build polipo using MinGW-w64

### DIFF
--- a/polipo.h
+++ b/polipo.h
@@ -60,7 +60,7 @@ THE SOFTWARE.
 #include <signal.h>
 #endif
 
-#ifdef __MINGW32_VERSION
+#ifdef __MINGW32__
 #define MINGW
 #endif
 


### PR DESCRIPTION
fixing this error
`util.o: In function mkgmtime:
/usr/i686-w64-mingw32/sys-root/mingw/include/time.h:241: undefined reference to _mkgmtime32
collect2: error: ld returned 1 exit status
Makefile:76: recipe for target polipo.exe failed
make: *** [polipo.exe] Error 1`
