### PR TITLE
Fix compiler warnings and types

### DIFF
--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -1,0 +1,146 @@
+PREFIX = /usr/local
+BINDIR = $(PREFIX)/bin
+MANDIR = $(PREFIX)/man
+INFODIR = $(PREFIX)/info
+LOCAL_ROOT = ./www
+DISK_CACHE_ROOT = ./cache
+
+# To compile with Unix CC:
+
+# CDEBUGFLAGS=-O
+
+# To compile with GCC:
+
+CC = gcc
+CXX = gcc
+CDEBUGFLAGS = -Os -g -Wall -fno-strict-aliasing
+
+# To compile on a pure POSIX system:
+
+# CC = c89
+# CC = c99
+# CDEBUGFLAGS=-O
+
+# To compile with icc 7, you need -restrict.  (Their bug.)
+
+# CC=icc
+# CDEBUGFLAGS = -O -restrict
+
+# On System V (Solaris, HP/UX) you need the following:
+
+# PLATFORM_DEFINES = -DSVR4
+
+# On Solaris, you need the following:
+
+# LDLIBS = -lsocket -lnsl -lresolv
+
+# On mingw, you need
+
+EXE=.exe
+LDLIBS = -lws2_32 -L/c/mingw/lib -lpcreposix -lpcre
+
+PLATFORM_DEFINES = -DHAVE_REGEX
+
+FILE_DEFINES = -DLOCAL_ROOT=\"$(LOCAL_ROOT)/\" \
+               -DDISK_CACHE_ROOT=\"$(DISK_CACHE_ROOT)/\"
+
+# You may optionally also add any of the following to DEFINES:
+#
+#  -DNO_DISK_CACHE to compile out the on-disk cache and local web server;
+#  -DNO_IPv6 to avoid using the RFC 3493 API and stick to stock
+#      Berkeley sockets;
+#  -DHAVE_IPv6 to force the use of the RFC 3493 API on systems other
+#      than GNU/Linux and BSD (let me know if it works);
+#  -DNO_FANCY_RESOLVER to compile out the asynchronous name resolution
+#      code;
+#  -DNO_STANDARD_RESOLVER to compile out the code that falls back to
+#      gethostbyname/getaddrinfo when DNS requests fail;
+#  -DNO_TUNNEL to compile out the code that handles CONNECT requests;
+#  -DNO_SOCKS to compile out the SOCKS gateway code.
+#  -DNO_FORBIDDEN to compile out the all of the forbidden URL code
+#  -DNO_REDIRECTOR to compile out the Squid-style redirector code
+#  -DNO_SYSLOG to compile out logging to syslog
+
+DEFINES = $(FILE_DEFINES) $(PLATFORM_DEFINES)
+
+CFLAGS = $(MD5INCLUDES) $(CDEBUGFLAGS) $(DEFINES) $(EXTRA_DEFINES)
+CXXFLAGS = $(CFLAGS)
+
+SRCS = util.c event.c io.c chunk.c atom.c object.c log.c diskcache.c main.c \
+       config.c local.c http.c client.c server.c auth.c tunnel.c \
+       http_parse.c parse_time.c dns.c forbidden.c \
+       md5import.c md5.c ftsimport.c fts_compat.c socks.c mingw.c
+
+OBJS = util.o event.o io.o chunk.o atom.o object.o log.o diskcache.o main.o \
+       config.o local.o http.o client.o server.o auth.o tunnel.o \
+       http_parse.o parse_time.o dns.o forbidden.o \
+       md5import.o ftsimport.o socks.o mingw.o
+
+polipo$(EXE): $(OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o polipo$(EXE) $(OBJS) $(MD5LIBS) $(LDLIBS)
+
+ftsimport.o: ftsimport.c fts_compat.c
+
+md5import.o: md5import.c md5.c
+
+.PHONY: all install install.binary install.man
+
+all: polipo$(EXE) polipo.info html/index.html localindex.html
+
+install: install.binary install.man
+
+install.binary: all
+	mkdir -p $(TARGET)$(BINDIR)
+	mkdir -p $(TARGET)$(LOCAL_ROOT)
+	mkdir -p $(TARGET)$(LOCAL_ROOT)/doc
+	rm -f $(TARGET)$(BINDIR)/polipo
+	cp -f polipo $(TARGET)$(BINDIR)/
+	cp -f html/* $(TARGET)$(LOCAL_ROOT)/doc
+	cp -f localindex.html $(TARGET)$(LOCAL_ROOT)/index.html
+
+install.man: all
+	mkdir -p $(TARGET)$(MANDIR)/man1
+	mkdir -p $(TARGET)$(INFODIR)
+	cp -f polipo.man $(TARGET)$(MANDIR)/man1/polipo.1
+	cp polipo.info $(TARGET)$(INFODIR)/
+	install-info --info-dir=$(TARGET)$(INFODIR) polipo.info
+
+
+polipo.info: polipo.texi
+	makeinfo polipo.texi
+
+html/index.html: polipo.texi
+	mkdir -p html
+	makeinfo --html -o html polipo.texi
+
+polipo.html: polipo.texi
+	makeinfo --html --no-split --no-headers -o polipo.html polipo.texi
+
+polipo.pdf: polipo.texi
+	texi2pdf polipo.texi
+
+polipo.ps.gz: polipo.ps
+	gzip -c polipo.ps > polipo.ps.gz
+
+polipo.ps: polipo.dvi
+	dvips -Pwww -o polipo.ps polipo.dvi
+
+polipo.dvi: polipo.texi
+	texi2dvi polipo.texi
+
+polipo.man.html: polipo.man
+	rman -f html polipo.man > polipo.man.html
+
+TAGS: $(SRCS)
+	etags $(SRCS)
+
+.PHONY: clean
+
+clean:
+	-rm -f polipo$(EXE) *.o *~ core TAGS gmon.out
+	-rm -f polipo.cp polipo.fn polipo.log polipo.vr
+	-rm -f polipo.cps polipo.info* polipo.pg polipo.toc polipo.vrs
+	-rm -f polipo.aux polipo.dvi polipo.ky polipo.ps polipo.tp
+	-rm -f polipo.dvi polipo.ps polipo.ps.gz polipo.pdf polipo.html
+	-rm -rf ./html/
+	-rm -f polipo.man.html

--- a/atom.c
+++ b/atom.c
@@ -87,8 +87,8 @@ internAtomN(const char *string, int n)
         atomHashTable[h] = atom;
         used_atoms++;
     }
-    do_log(D_ATOM_REFCOUNT, "A 0x%lx %d++\n",
-           (unsigned long)atom, atom->refcount);
+    do_log(D_ATOM_REFCOUNT, "A 0x%" PRIxPTR " %d++\n",
+           (intptr_t)atom, atom->refcount);
     atom->refcount++;
     return atom;
 }
@@ -169,8 +169,8 @@ retainAtom(AtomPtr atom)
     if(atom == NULL)
         return NULL;
 
-    do_log(D_ATOM_REFCOUNT, "A 0x%lx %d++\n",
-           (unsigned long)atom, atom->refcount);
+    do_log(D_ATOM_REFCOUNT, "A 0x%" PRIxPTR " %d++\n",
+           (intptr_t)atom, atom->refcount);
     assert(atom->refcount >= 1 && atom->refcount < LARGE_ATOM_REFCOUNT);
     atom->refcount++;
     return atom;
@@ -182,8 +182,8 @@ releaseAtom(AtomPtr atom)
     if(atom == NULL)
         return;
 
-    do_log(D_ATOM_REFCOUNT, "A 0x%lx %d--\n",
-           (unsigned long)atom, atom->refcount);
+    do_log(D_ATOM_REFCOUNT, "A 0x%" PRIxPTR " %d--\n",
+           (intptr_t)atom, atom->refcount);
     assert(atom->refcount >= 1 && atom->refcount < LARGE_ATOM_REFCOUNT);
 
     atom->refcount--;

--- a/client.c
+++ b/client.c
@@ -105,8 +105,8 @@ httpAccept(int fd, FdEventHandlerPtr event, AcceptRequestPtr request)
     connection->fd = fd;
     connection->timeout = timeout;
 
-    do_log(D_CLIENT_CONN, "Accepted client connection 0x%lx\n",
-           (unsigned long)connection);
+    do_log(D_CLIENT_CONN, "Accepted client connection 0x%" PRIxPTR "\n",
+           (intptr_t)connection);
 
     connection->flags = CONN_READER;
 
@@ -236,8 +236,8 @@ httpClientFinish(HTTPConnectionPtr connection, int s)
         return;
     }
     
-    do_log(D_CLIENT_CONN, "Closing client connection 0x%lx\n",
-           (unsigned long)connection);
+    do_log(D_CLIENT_CONN, "Closing client connection 0x%" PRIxPTR "\n",
+           (intptr_t)connection);
 
     if(connection->flags & CONN_READER) {
         httpSetTimeout(connection, 10);
@@ -1795,8 +1795,8 @@ httpServeObject(HTTPConnectionPtr connection)
 
     connection->offset = request->from;
     httpSetTimeout(connection, clientTimeout);
-    do_log(D_CLIENT_DATA, "Serving on 0x%lx for 0x%lx: offset %d len %d\n",
-           (unsigned long)connection, (unsigned long)object,
+    do_log(D_CLIENT_DATA, "Serving on 0x%" PRIxPTR " for 0x%" PRIxPTR ": offset %d len %d\n",
+           (intptr_t)connection, (intptr_t)object,
            connection->offset, len);
     do_stream_h(IO_WRITE |
                 (connection->te == TE_CHUNKED && len > 0 ? IO_CHUNKED : 0),
@@ -1987,8 +1987,8 @@ httpServeChunk(HTTPConnectionPtr connection)
         if(len2 == 0) {
             httpSetTimeout(connection, clientTimeout);
             do_log(D_CLIENT_DATA, 
-                   "Serving on 0x%lx for 0x%lx: offset %d len %d\n",
-                   (unsigned long)connection, (unsigned long)object,
+                   "Serving on 0x%" PRIxPTR " for 0x%" PRIxPTR ": offset %d len %d\n",
+                   (intptr_t)connection, (intptr_t)object,
                    connection->offset, len);
             /* IO_NOTNOW in order to give other clients a chance to run. */
             do_stream(IO_WRITE | IO_NOTNOW |
@@ -2000,8 +2000,8 @@ httpServeChunk(HTTPConnectionPtr connection)
         } else {
             httpSetTimeout(connection, clientTimeout);
             do_log(D_CLIENT_DATA, 
-                   "Serving on 0x%lx for 0x%lx: offset %d len %d + %d\n",
-                   (unsigned long)connection, (unsigned long)object,
+                   "Serving on 0x%" PRIxPTR " for 0x%" PRIxPTR ": offset %d len %d + %d\n",
+                   (intptr_t)connection, (intptr_t)object,
                    connection->offset, len, len2);
             do_stream_2(IO_WRITE | IO_NOTNOW |
                         (connection->te == TE_CHUNKED ? IO_CHUNKED : 0) |

--- a/dns.c
+++ b/dns.c
@@ -104,7 +104,7 @@ static int sendQuery(DnsQueryPtr query);
 static int idSeed;
 #endif
 
-#ifndef NO_FANCY_RESOLVER
+#if !defined(NO_FANCY_RESOLVER) && !defined(WIN32)
 static int
 parseResolvConf(char *filename)
 {

--- a/dns.c
+++ b/dns.c
@@ -1402,7 +1402,7 @@ labelsToString(char *buf, int offset, int n, char *d, int m, int *j_return)
     int i = offset, j, k;
     int ll, rc;
 
-    j = 0;
+    j = k = 0;
     while(1) {
         if(i >= n) return -1;
         ll = *(unsigned char*)&buf[i]; i++;

--- a/forbidden.c
+++ b/forbidden.c
@@ -474,9 +474,8 @@ urlForbidden(AtomPtr url,
         return 1;
     }
 
-#endif
-
  done:
+ #endif
     handler(code, url, message, headers, closure);
     return 1;
 }

--- a/fts_compat.c
+++ b/fts_compat.c
@@ -240,7 +240,9 @@ fts_read(FTS *fts)
     struct dirent *dirent;
     int rc;
     char *name;
+#ifdef S_ISLNK
     char buf[1024];
+#endif
 
     if(fts->ftsent.fts_path) {
         free(fts->ftsent.fts_path);
@@ -284,7 +286,9 @@ fts_read(FTS *fts)
 
     name = dirent->d_name;
 
+#ifdef S_ISLNK
  again2:
+#endif
     rc = stat(name, &fts->ftstat);
     if(rc < 0) {
         fts->ftsent.fts_info = FTS_NS;

--- a/http.c
+++ b/http.c
@@ -260,8 +260,8 @@ httpSetTimeout(HTTPConnectionPtr connection, int secs)
         new = scheduleTimeEvent(secs, httpTimeoutHandler,
                                 sizeof(connection), &connection);
         if(!new) {
-            do_log(L_ERROR, "Couldn't schedule timeout for connection 0x%lx\n",
-                   (unsigned long)connection);
+            do_log(L_ERROR, "Couldn't schedule timeout for connection 0x%" PRIxPTR "\n",
+                   (intptr_t)connection);
             return -1;
         }
     } else {

--- a/io.c
+++ b/io.c
@@ -686,7 +686,6 @@ create_listener(char *address, int port,
                 void *data)
 {
     int fd, rc;
-    int one = 1;
     int done;
     struct sockaddr_in addr;
 #ifdef HAVE_IPv6

--- a/io.c
+++ b/io.c
@@ -661,7 +661,7 @@ do_scheduled_accept(int status, FdEventHandlerPtr event)
 {
     AcceptRequestPtr request = (AcceptRequestPtr)&event->data;
     int rc, done;
-    unsigned len;
+    socklen_t len;
     struct sockaddr_in addr;
 
     if(status) {
@@ -1100,7 +1100,7 @@ int
 netAddressMatch(int fd, NetAddressPtr list)
 {
     int rc;
-    unsigned int len;
+    socklen_t len;
     struct sockaddr_in sain;
 #ifdef HAVE_IPv6
     struct sockaddr_in6 sain6;

--- a/mingw.c
+++ b/mingw.c
@@ -266,7 +266,7 @@ int win32_close_socket(SOCKET fd) {
     int rc;
 
     rc = closesocket(fd);
-    return 0;
+    return rc;
 }
 
 static void

--- a/mingw.h
+++ b/mingw.h
@@ -153,8 +153,6 @@ struct pollfd {
 /* Winsock uses int instead of the usual socklen_t */
 typedef int socklen_t;
 
-typedef int pid_t;
-
 /* Function prototypes for functions in mingw.c */
 unsigned int win32_sleep(unsigned int);
 int     win32_inet_aton(const char *, struct in_addr *);

--- a/object.c
+++ b/object.c
@@ -275,8 +275,8 @@ objectMetadataChanged(ObjectPtr object, int revalidate)
 ObjectPtr
 retainObject(ObjectPtr object)
 {
-    do_log(D_REFCOUNT, "O 0x%lx %d++\n",
-           (unsigned long)object, object->refcount);
+    do_log(D_REFCOUNT, "O 0x%" PRIxPTR " %d++\n",
+           (intptr_t)object, object->refcount);
     object->refcount++;
     return object;
 }
@@ -284,8 +284,8 @@ retainObject(ObjectPtr object)
 void
 releaseObject(ObjectPtr object)
 {
-    do_log(D_REFCOUNT, "O 0x%lx %d--\n",
-           (unsigned long)object, object->refcount);
+    do_log(D_REFCOUNT, "O 0x%" PRIxPTR " %d--\n",
+           (intptr_t)object, object->refcount);
     object->refcount--;
     if(object->refcount == 0) {
         assert(!object->condition.handlers && 
@@ -298,8 +298,8 @@ releaseObject(ObjectPtr object)
 void
 releaseNotifyObject(ObjectPtr object)
 {
-    do_log(D_REFCOUNT, "O 0x%lx %d--\n",
-           (unsigned long)object, object->refcount);
+    do_log(D_REFCOUNT, "O 0x%" PRIxPTR " %d--\n",
+           (intptr_t)object, object->refcount);
     object->refcount--;
     if(object->refcount > 0) {
         notifyObject(object);
@@ -314,7 +314,7 @@ releaseNotifyObject(ObjectPtr object)
 void 
 lockChunk(ObjectPtr object, int i)
 {
-    do_log(D_LOCK, "Lock 0x%lx[%d]: ", (unsigned long)object, i);
+    do_log(D_LOCK, "Lock 0x%" PRIxPTR "[%d]: ", (intptr_t)object, i);
     assert(i >= 0);
     if(i >= object->numchunks)
         objectSetChunks(object, i + 1);
@@ -325,7 +325,7 @@ lockChunk(ObjectPtr object, int i)
 void 
 unlockChunk(ObjectPtr object, int i)
 {
-    do_log(D_LOCK, "Unlock 0x%lx[%d]: ", (unsigned long)object, i);
+    do_log(D_LOCK, "Unlock 0x%" PRIxPTR "[%d]: ", (intptr_t)object, i);
     assert(i >= 0 && i < object->numchunks);
     assert(object->chunks[i].locked > 0);
     object->chunks[i].locked--;
@@ -479,8 +479,8 @@ objectAddData(ObjectPtr object, const char *data, int offset, int len)
 {
     int rc;
 
-    do_log(D_OBJECT_DATA, "Adding data to 0x%lx (%d) at %d: %d bytes\n",
-           (unsigned long)object, object->length, offset, len);
+    do_log(D_OBJECT_DATA, "Adding data to 0x%" PRIxPTR " (%d) at %d: %d bytes\n",
+           (intptr_t)object, object->length, offset, len);
 
     if(len == 0)
         return 1;

--- a/polipo.h
+++ b/polipo.h
@@ -35,6 +35,7 @@ THE SOFTWARE.
 #include <errno.h>
 #include <string.h>
 #include <assert.h>
+#include <inttypes.h>
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/time.h>

--- a/server.c
+++ b/server.c
@@ -1617,9 +1617,9 @@ httpWriteRequest(HTTPConnectionPtr connection, HTTPRequestPtr request,
     do_log_n(D_SERVER_REQ, url + x, y - x);
     do_log(D_SERVER_REQ, ": ");
     do_log_n(D_SERVER_REQ, connection->reqbuf, n);
-    do_log(D_SERVER_REQ, " (method %d from %d to %d, 0x%lx for 0x%lx)\n",
+    do_log(D_SERVER_REQ, " (method %d from %d to %d, 0x%" PRIxPTR " for 0x%" PRIxPTR ")\n",
            method, from, to,
-           (unsigned long)connection, (unsigned long)object);
+           (intptr_t)connection, (intptr_t)object);
 
     n = snnprintf(connection->reqbuf, n, bufsize, " HTTP/1.1");
 
@@ -1723,8 +1723,8 @@ httpServerHandler(int status,
     assert(connection->request->object->flags & OBJECT_INPROGRESS);
 
     if(connection->reqlen == 0) {
-        do_log(D_SERVER_REQ, "Writing aborted on 0x%lx\n",
-               (unsigned long)connection);
+        do_log(D_SERVER_REQ, "Writing aborted on 0x%" PRIxPTR "\n",
+               (intptr_t)connection);
         goto fail;
     }
 
@@ -1763,7 +1763,7 @@ httpServerSendRequest(HTTPConnectionPtr connection)
 
     if(connection->reqlen == 0) {
         do_log(D_SERVER_REQ, 
-               "Writing aborted on 0x%lx\n", (unsigned long)connection);
+               "Writing aborted on 0x%" PRIxPTR "\n", (intptr_t)connection);
         httpConnectionDestroyReqbuf(connection);
         shutdown(connection->fd, 2);
         pokeFdEvent(connection->fd, -EDOSHUTDOWN, POLLIN | POLLOUT);
@@ -1903,8 +1903,8 @@ httpServerHandlerHeaders(int eof,
     do_log(D_SERVER_REQ, "Server status: ");
     do_log_n(D_SERVER_REQ, connection->buf, 
              connection->buf[rc - 1] == '\r' ? rc - 2 : rc - 2);
-    do_log(D_SERVER_REQ, " (0x%lx for 0x%lx)\n",
-           (unsigned long)connection, (unsigned long)object);
+    do_log(D_SERVER_REQ, " (0x%" PRIxPTR " for 0x%" PRIxPTR ")\n",
+           (intptr_t)connection, (intptr_t)object);
 
     if(version != HTTP_10 && version != HTTP_11) {
         do_log(L_ERROR, "Unknown server HTTP version\n");
@@ -2317,8 +2317,8 @@ httpServerHandlerHeaders(int eof,
     if(content_range.to >= 0)
         request->to = content_range.to;
 
-    do_log(D_SERVER_OFFSET, "0x%lx(0x%lx): offset = %d\n",
-           (unsigned long)connection, (unsigned long)object,
+    do_log(D_SERVER_OFFSET, "0x%" PRIxPTR "(0x%" PRIxPTR "): offset = %d\n",
+           (intptr_t)connection, (intptr_t)object,
            connection->offset);
 
     if(connection->len > rc) {
@@ -2706,8 +2706,8 @@ connectionAddData(HTTPConnectionPtr connection, int skip)
                 return -1;
             connection->offset += len;
             connection->len -= (len + skip);
-            do_log(D_SERVER_OFFSET, "0x%lx(0x%lx): offset = %d\n",
-                   (unsigned long)connection, (unsigned long)object,
+            do_log(D_SERVER_OFFSET, "0x%" PRIxPTR "(0x%" PRIxPTR "): offset = %d\n",
+                   (intptr_t)connection, (intptr_t)object,
                    connection->offset);
         }
 
@@ -2771,9 +2771,9 @@ connectionAddData(HTTPConnectionPtr connection, int skip)
                         return -1;
                     i += size;
                     connection->chunk_remaining -= size;
-                    do_log(D_SERVER_OFFSET, "0x%lx(0x%lx): offset = %d\n",
-                           (unsigned long)connection, 
-                           (unsigned long)object,
+                    do_log(D_SERVER_OFFSET, "0x%" PRIxPTR "(0x%" PRIxPTR "): offset = %d\n",
+                           (intptr_t)connection, 
+                           (intptr_t)object,
                            connection->offset);
                 }
             }


### PR DESCRIPTION
These changes were made to remove warnings while making polipo compile under mingw64.

Most changes are regarding pointer type portability issues.