### PR TITLE
Add support for DELETE method

### DIFF
--- a/client.c
+++ b/client.c
@@ -739,7 +739,8 @@ httpClientRequest(HTTPRequestPtr request, AtomPtr url)
 
     if(body_len < 0) {
         if(request->method == METHOD_GET || request->method == METHOD_HEAD ||
-           request->method == METHOD_POST || request->method == METHOD_OPTIONS)
+           request->method == METHOD_POST || request->method == METHOD_OPTIONS ||
+           request->method == METHOD_DELETE)
             body_len = 0;
     }
     connection->bodylen = body_len;
@@ -869,7 +870,7 @@ httpClientRequestContinue(int forbidden_code, AtomPtr url,
         httpServerRequest;
 
     if(request->method == METHOD_POST || request->method == METHOD_PUT ||
-       request->method == METHOD_OPTIONS) {
+       request->method == METHOD_OPTIONS || request->method == METHOD_DELETE) {
         do {
             object = findObject(OBJECT_HTTP, url->string, url->length);
             if(object) {

--- a/http.h
+++ b/http.h
@@ -106,6 +106,7 @@ typedef struct _HTTPConnection {
 #define METHOD_POST 4
 #define METHOD_PUT 5
 #define METHOD_OPTIONS 6
+#define METHOD_DELETE 7
 
 #define REQUEST_SIDE(request) ((request)->method >= METHOD_POST)
 

--- a/http_parse.c
+++ b/http_parse.c
@@ -419,6 +419,8 @@ httpParseClientFirstLine(const char *restrict buf, int offset,
         method = METHOD_CONNECT;
     else if(y == x + 7 && memcmp(buf + x, "OPTIONS", 7) == 0)
         method = METHOD_OPTIONS;
+    else if(y == x + 6 && memcmp(buf + x, "DELETE", 6) == 0)
+        method = METHOD_DELETE;
     else
         method = METHOD_UNKNOWN;
 

--- a/polipo.texi
+++ b/polipo.texi
@@ -286,6 +286,7 @@ missing data.
 @cindex PUT request
 @cindex POST request
 @cindex OPTIONS request
+@cindex DELETE request
 @cindex PROPFIND request
 
 The previous sections pretend that there is only one kind of request
@@ -305,7 +306,7 @@ results cacheable.}.  The @samp{PUT} method is used to replace an
 resource with a different instance; it is typically used by web
 publishing applications.
 
-@samp{POST}, @samp{PUT} and @samp{OPTIONS} requests are handled by
+@samp{POST}, @samp{PUT}, @samp{OPTIONS} and @samp{DELETE} requests are handled by
 Polipo pretty much like @samp{GET} and @samp{HEAD}; however, for various
 reasons, some precautions must be taken.  In particular, any cached data
 for the resource they refer to must be discarded, and they can never be

--- a/server.c
+++ b/server.c
@@ -468,7 +468,7 @@ httpMakeServerRequest(char *name, int port, ObjectPtr object,
         }
     } else if(expectContinue >= 2 && server->version == HTTP_11) {
         if(request->method == METHOD_POST || request->method == METHOD_PUT ||
-           request->method == METHOD_OPTIONS)
+           request->method == METHOD_OPTIONS || request->method == METHOD_DELETE)
             request->flags |= REQUEST_WAIT_CONTINUE;
     }
         
@@ -1595,6 +1595,7 @@ httpWriteRequest(HTTPConnectionPtr connection, HTTPRequestPtr request,
     case METHOD_POST: m = "POST"; break;
     case METHOD_PUT: m = "PUT"; break;
     case METHOD_OPTIONS: m = "OPTIONS"; break;
+    case METHOD_DELETE: m = "DELETE"; break;
     default: abort();
     }
     n = snnprintf(connection->reqbuf, n, bufsize, "%s ", m);


### PR DESCRIPTION
In line with 108242d1edc21c32453b9e0a69d449a03fb85430, I added support for the DELETE method, which is used bei most REST APIs. Support for this in Polipo comes in handy when the sending server does not have direct access to the internet (e.g. in an Amazon VPC).
This patch is already used in production for a while and works reliable. 