### PR TITLE
adding support for ignoring credentials in URL

### DIFF
--- a/http_parse.c
+++ b/http_parse.c
@@ -1426,8 +1426,17 @@ parseUrl(const char *url, int len,
             }
         } else {
             for(i = x; i < len; i++)
-                if(url[i] == ':' || url[i] == '/')
+tryagain:
+                if(url[i] == ':' || url[i] == '/') {
+                    int tom = i;
+                    while (url[tom] != '/') {
+                        if (url[tom++] == '@') {
+                            x = i = tom;
+                            goto tryagain;
+                        }
+                    }
                     break;
+                }
         }
         y = i;
 


### PR DESCRIPTION
Related to https://github.com/jech/polipo/issues/75

This "fix" isn't ideal in that it just ignores the crednetials instead of doing something useful with them, e.g., when you curl with credentials in the url, curl adds them as a base64 encoded string to an `Authorization: Basic` header automatically.